### PR TITLE
Reorganize Phase 1 completion and document Phase 3 bring-up plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -6,144 +6,127 @@ The goal is to add BCM4360 support to the Linux kernel's `brcmfmac` driver by re
 
 We have a live BCM4360 device on this machine with the `wl` driver loaded, giving us the ability to trace driver behaviour, read hardware registers, and compare against the existing `brcmfmac` codebase.
 
-## What We Know So Far
+## Current Status
 
-### The chip
-- BCM4360, PCI ID `14e4:43a0` rev 03, Apple subsystem `106b:0112`
-- FullMAC architecture: the 802.11ac stack runs on an ARM Cortex-R4 (or M3) inside the chip
-- Contains a proprietary Broadcom "D11 core" for the PHY layer
-- Internal cores are connected via a BCMA backplane (same bus used by other Broadcom chips)
-- Firmware is split into ROM (baked into silicon) and RAM (loaded by the host driver)
-- PCIe interface with two BARs: 32KB control registers (BAR0) and 2MB backplane window (BAR2)
+**Phase 1 is complete.** Phase 1 analysis revealed that the BCM4360 is architecturally near-identical to the already-supported BCM43602 — same ARM CR4 CPU, same PCIe Gen2 core, same BCMA backplane. A minimal brcmfmac patch adding PCI/chip IDs, TCM rambase, and firmware mappings has been written, a build system exists, and testing instructions are documented.
 
-### The existing proprietary driver (`wl`)
-- Hybrid driver: open-source shim wrapping two proprietary ELF objects (`wl.o`, `wlc_hybrid.o_shipped`)
-- Contains embedded firmware that is loaded onto the chip's ARM core at init
-- Shares significant code with the on-chip firmware (per Quarkslab analysis)
-- The driver and firmware share APIs — vulnerabilities in one are present in the other
-- Currently loaded and functional on this machine
+**The project has moved directly to patched brcmfmac bring-up** (Phase 3), bypassing MMIO tracing (Phase 2). The central question is now:
 
-### The existing open-source driver (`brcmfmac`)
-- Supports other Broadcom FullMAC chips (BCM4339, BCM4354, BCM4356, BCM43602, BCM4387, etc.)
-- Uses `msgbuf` protocol for PCIe devices, `BCDC` for SDIO/USB
-- Handles firmware loading, backplane enumeration, and host-firmware messaging
-- Maintained by Arend van Spriel at Broadcom
-- BCM4360 is explicitly **not supported** — no chip ID, no firmware interface mapping
+> **How far does the real probe get, and where exactly does it fail?**
 
-### Why brcmfmac doesn't support BCM4360 today
-- Broadcom has never released FullMAC firmware for this chip separately
-- The chip may use an older or different variant of the messaging protocol
-- Nobody has mapped the specific firmware interface (commands, events, init sequence)
-- Arend van Spriel acknowledged it would require "porting everything from fmac to smac" — though this may refer to a different technical approach than what we're attempting
+The answer determines whether this is a small compatibility gap or a deeper reverse-engineering effort.
 
 ---
 
-## Phase 1: Reconnaissance (no risk to running system)
+## Phase 1: Reconnaissance ✅ COMPLETE
 
-### 1.1 — Enumerate BCMA backplane cores
-**Goal:** Identify what internal cores exist on the chip and at what addresses.
+### 1.1 — Enumerate BCMA backplane cores ✅
+**Result:** 9 cores identified — ARM CR4 (rev 2), D11 (rev 42), PCIe Gen2 (rev 1), ChipCommon (rev 43), USB 2.0 Device, plus ARM infrastructure cores. Layout is very similar to brcmfmac-supported chips.
 
-**Method:** Read the BCMA enumeration ROM via BAR2. The BCMA bus stores a table of core descriptors at a known offset. Each entry identifies a core type (ARM, D11, PCIe, USB, etc.), its address range, and revision.
+See: `phase1/notes/core_enumeration_analysis.md`
 
-**Tools:** Python script reading `/sys/bus/pci/devices/0000:03:00.0/resource2`
+### 1.2 — Extract firmware from `wl.ko` ✅
+**Result:** Two firmware variants extracted — `4352pci` (432KB) and `4350pci` (435KB), both version 6.30.223.0 (Dec 2013). Thumb-2 ARM binaries running hndrte RTOS. Firmware contains both `bcmcdc.c` and `pciedev_msg.c` references — BCDC encapsulation within PCIe dongle messaging.
 
-**Output:** A table of core types, addresses, and revisions — compare against brcmfmac's supported layouts.
+See: `phase1/notes/firmware_extraction_analysis.md`
 
-**Risk:** Read-only. No writes to hardware. Safe while `wl` is running.
+### 1.3 — Study brcmfmac source for supported chip patterns ✅
+**Result:** BCM4360 needs only ~10 lines of code to add to brcmfmac: PCI device ID, chip ID, TCM rambase (0x180000), and firmware name mapping. The biggest unknown is the shared memory protocol version (must be 5-7 for msgbuf).
 
-### 1.2 — Extract firmware from `wl.ko`
-**Goal:** Pull out the ARM firmware blob embedded in the proprietary driver module.
-
-**Method:** Use `binwalk`, `objdump`, and manual analysis on the `wl.ko` file. The firmware is likely a contiguous ARM binary within one of the ELF sections. Look for ARM vector tables (reset, IRQ, etc.) and known Broadcom firmware headers.
-
-**Tools:** `binwalk`, `objdump`, `readelf`, `hexdump`, custom Python scripts
-
-**Output:** Raw firmware binary, entry point, load address, size. Compare against known brcmfmac firmware file formats (`.bin`, `.clm_blob`).
-
-**Risk:** None — analysing a file on disk.
-
-### 1.3 — Study brcmfmac source for supported chip patterns
-**Goal:** Understand what brcmfmac expects from a FullMAC PCIe chip, so we know what we need to provide for BCM4360.
-
-**Method:** Read the kernel source — specifically:
-- `drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c` — PCIe bus layer
-- `drivers/net/wireless/broadcom/brcm80211/brcmfmac/msgbuf.c` — host-firmware protocol
-- `drivers/net/wireless/broadcom/brcm80211/brcmfmac/chip.c` — chip identification and core enumeration
-- `drivers/net/wireless/broadcom/brcm80211/brcmfmac/firmware.c` — firmware loading
-
-**Output:** Documentation of the init sequence, protocol handshake, and chip-specific hooks.
-
-**Risk:** None — reading source code.
+See: `phase1/notes/brcmfmac_analysis.md`
 
 ---
 
-## Phase 2: Active Tracing
+## Phase 2: MMIO Tracing (fallback — use if Phase 3 hits a wall)
+
+> **Note:** This phase was originally the planned path before attempting brcmfmac. Since Phase 1 analysis showed the chip is close to supported chips, the project jumped directly to Phase 3. MMIO tracing remains available as a diagnostic tool if the patched module fails in ways that can't be diagnosed from dmesg alone.
 
 ### 2.1 — Trace `wl` driver MMIO access during initialization
-**Goal:** Capture the complete sequence of register reads/writes the `wl` driver performs during module load and device init.
+**Goal:** Capture the complete register read/write sequence during `wl` module load.
 
-**Method:** Unload and reload the `wl` module with `ftrace` or `kprobes` active on `ioread32`/`iowrite32`. Alternatively, use `mmiotrace` (kernel's MMIO tracing facility) which logs all MMIO access.
+**Method:** Unload and reload `wl` with `mmiotrace` or `ftrace` on `ioread32`/`iowrite32`.
 
-**Tools:** `trace-cmd`, `mmiotrace`, custom `ftrace` setup
+**When to use:** If Phase 3 produces failures related to chip initialization, register access patterns, or undocumented hardware behavior.
 
-**Output:** A timestamped log of every register address read/written, with values. This is the chip's initialization sequence.
+**Risk:** Moderate — requires reloading WiFi driver. USB adapter provides backup connectivity.
 
-**Risk:** Moderate — requires reloading the WiFi driver. Will temporarily lose WiFi on that interface. The USB adapter can provide connectivity during this work.
+### 2.2 — Trace `wl` during scan, associate, and data transfer
+**Goal:** Capture host-firmware command/response protocol for key WiFi operations.
 
-### 2.2 — Trace `wl` driver during scan, associate, and data transfer
-**Goal:** Capture the host-firmware command/response protocol for key operations.
-
-**Method:** Same MMIO tracing, but trigger WiFi operations (scan for networks, connect to AP, transfer data) while tracing is active.
-
-**Output:** Command structures, event formats, ring buffer usage patterns — the protocol we need to replicate.
-
-**Risk:** Same as 2.1 — WiFi disruption during tracing.
+**When to use:** If the chip probes successfully but protocol-level operations fail (scan, associate, data path).
 
 ### 2.3 — Compare traced patterns against brcmfmac msgbuf protocol
-**Goal:** Determine whether BCM4360 uses standard `msgbuf` protocol or a variant.
+**Goal:** Determine whether BCM4360 uses standard `msgbuf` or a variant.
 
-**Method:** Align traced MMIO sequences against brcmfmac's `msgbuf` implementation. Look for shared ring buffer structures, doorbell registers, and message types.
-
-**Output:** A mapping of BCM4360's protocol to brcmfmac concepts — what's the same, what differs.
-
-**Risk:** None — analysis work.
+**When to use:** If protocol version mismatch or unexpected message formats are observed.
 
 ---
 
-## Phase 3: Proof of Concept
+## Phase 3: Patched brcmfmac Bring-up ← CURRENT PHASE
 
-### 3.1 — Write a userspace probe tool
-**Goal:** A tool that can initialize the chip, enumerate cores, and send basic commands — without the `wl` driver loaded.
+This is now the primary path. A proof-of-concept patch exists; the focus is on running a clean test and capturing results.
 
-**Method:** Python or C tool using `/dev/mem` or a small kernel module to access MMIO. Replay the initialization sequence captured in Phase 2.
+### 3.1 — Rebuild module against exact running kernel
+**Goal:** Eliminate kernel version mismatch as a failure mode.
 
-**Output:** Evidence that we can bring the chip up and communicate with the firmware independently of `wl`.
+**Status:** Module was built against 6.12.80; running kernel is 6.12.78. Must rebuild.
 
-**Risk:** High — writing to hardware registers with `wl` unloaded. Could hang the chip or PCIe bus. Mitigated by having the USB adapter for recovery and using PCI reset to recover the device.
+**Method:** Update the Nix expression or build script to target the exact running kernel headers. Verify module `vermagic` matches before testing.
 
-### 3.2 — Attempt firmware load via brcmfmac path
-**Goal:** Try loading the extracted firmware using brcmfmac's firmware loading code path.
+**Output:** `phase3/output/brcmfmac.ko` with correct vermagic.
 
-**Method:** Add BCM4360's PCI ID to brcmfmac, place the extracted firmware where brcmfmac expects it, and attempt to load the module.
+### 3.2 — Prepare firmware and NVRAM files
+**Goal:** Ensure the correct firmware layout is in place before testing.
 
-**Output:** Either it works (partially or fully) or it fails with specific errors that guide further work.
+**Method:** See the firmware workstreams tracker (`phase3/notes/firmware_workstreams.md`) for the full status of each component:
+- **Firmware binary** — place extracted firmware as `/lib/firmware/brcm/brcmfmac4360-pcie.bin`
+- **NVRAM** — determine source (SPROM, extracted, or none) and place as `.txt` if available
+- **CLM blob** — determine if needed and provide if so
 
-**Risk:** Moderate — loading an experimental kernel module. Worst case: kernel panic, reboot required.
+**Output:** Complete `/lib/firmware/brcm/` layout documented in test results.
+
+### 3.3 — Run first real test and capture results
+**Goal:** Load the patched module and determine exactly where probe succeeds or fails.
+
+**Method:**
+1. Switch to USB WiFi adapter for connectivity
+2. Unload `wl` driver
+3. Load patched `brcmfmac.ko` and `brcmfmac-wcc.ko`
+4. Capture full `dmesg` output
+
+**Output:** Full logs saved to `phase3/results/`, with a summary of the exact failure point:
+- Module load failure
+- Firmware load failure
+- NVRAM missing
+- Protocol version mismatch
+- Dongle setup failure
+- Interface successfully created
+
+See: `phase3/notes/testing_instructions.md`
+
+### 3.4 — Analyze results and iterate
+**Goal:** Based on the first test, determine the next action.
+
+**Decision tree:**
+- **Protocol version mismatch** → investigate firmware's shared memory format, may need Phase 2 tracing
+- **Firmware load failure** → check firmware format (TRX header?), try alternate variant
+- **NVRAM missing** → extract from SPROM or `wl` driver
+- **Dongle setup failure** → firmware loaded but init handshake failed, investigate with tracing
+- **Interface created** → proceed to Phase 4
 
 ---
 
-## Phase 4: Driver Development
+## Phase 4: Driver Development and Upstreaming
 
-### 4.1 — Patch brcmfmac for BCM4360 support
-**Goal:** A working brcmfmac patch that supports BCM4360.
+### 4.1 — Validate and harden the patch
+**Goal:** Move from proof-of-concept to review-ready patch.
 
-**Method:** Based on findings from Phases 1-3:
-- Add chip ID and core table to `chip.c`
-- Add firmware file mapping to `firmware.c`
-- Add any protocol quirks to `pcie.c` / `msgbuf.c`
-- Handle any BCM4360-specific initialization
-
-**Output:** A kernel patch that can be tested and submitted for review.
+**Actions:**
+- Separate BCM4360 and BCM4352 support unless both are strictly needed
+- Regenerate patch from a clean kernel tree (not from approximate hunks)
+- Update commit message with observed runtime behavior
+- Add any chip-specific quirks discovered during testing
+- Handle any BCM4360-specific initialization (e.g., USB core disable)
 
 ### 4.2 — Test basic functionality
 **Goal:** Verify scanning, association, and data transfer work.
@@ -158,6 +141,18 @@ We have a live BCM4360 device on this machine with the `wl` driver loaded, givin
 **Method:** Submit to `linux-wireless@vger.kernel.org` and `brcm80211@lists.linux.dev`, CC Arend van Spriel. Follow kernel patch submission process.
 
 **Output:** BCM4360 support in mainline Linux.
+
+---
+
+## Patch Assumptions
+
+The current proof-of-concept patch makes several assumptions that need validation. See `phase3/notes/patch_assumptions.md` for the full list with evidence and verification status.
+
+Key assumptions:
+- BCM4360 behaves like BCM43602-family chips
+- TCM rambase = `0x180000`
+- Firmware mapping `brcmfmac4360-pcie` is sufficient for probe
+- The extracted firmware uses msgbuf-compatible shared memory protocol (version 5-7)
 
 ---
 

--- a/phase3/notes/firmware_workstreams.md
+++ b/phase3/notes/firmware_workstreams.md
@@ -1,0 +1,82 @@
+# Phase 3 Firmware Workstreams
+
+**Date:** 2026-04-12
+
+Each component needed for a successful brcmfmac probe is tracked separately. All three must be resolved before a clean test.
+
+---
+
+## 1. Firmware Binary (`brcmfmac4360-pcie.bin`)
+
+**Status:** Available, variant uncertain
+
+**What we have:**
+- Two extracted variants from `wl.ko` 6.30.223.271:
+  - `phase1/output/firmware_4352pci.bin` — 431.9KB, CRC ff98ca92
+  - `phase1/output/firmware_4350pci.bin` — 435.3KB, CRC ffcf9e98
+- Both are version 6.30.223.0, built 2013-12-15
+- Thumb-2 ARM binaries targeting ARM CR4
+
+**Open questions:**
+- [ ] Which variant does BCM4360 (0x43a0) actually use? Testing instructions default to `4352pci` based on chip family proximity, but this is a guess.
+- [ ] Does brcmfmac expect a TRX header on the firmware? If so, our raw binary may need wrapping.
+- [ ] Is the 2013-era firmware compatible with brcmfmac's msgbuf protocol (version 5-7)?
+
+**Install path:** `/lib/firmware/brcm/brcmfmac4360-pcie.bin`
+
+**First test plan:** Use `firmware_4352pci.bin`. If it fails, try `firmware_4350pci.bin`.
+
+---
+
+## 2. NVRAM (`brcmfmac4360-pcie.txt`)
+
+**Status:** Not yet sourced
+
+**What NVRAM provides:**
+Board-specific calibration data — TX power levels, antenna configuration, regulatory domain, MAC address, crystal frequency, PA parameters. Without it, brcmfmac may:
+- Use defaults (may work poorly or not at all)
+- Read from SPROM on the card (if present and if brcmfmac supports it for this chip)
+- Fail probe entirely
+
+**Possible sources:**
+- [ ] **SPROM on the PCIe card** — brcmfmac can read SPROM for some chips. Check if BCM4360 SPROM reading is supported.
+- [ ] **Embedded in `wl.ko`** — the proprietary driver may contain default NVRAM. Look for `boardtype=`, `macaddr=`, `pa2gw0a0=` patterns in the binary.
+- [ ] **macOS nvram** — Apple stores WiFi calibration in NVRAM on Macs. If this is a MacBook, it may be accessible via `nvram` or firmware tables.
+- [ ] **None needed** — some firmwares have built-in defaults. Unlikely for production hardware.
+
+**Install path:** `/lib/firmware/brcm/brcmfmac4360-pcie.txt`
+
+**First test plan:** Attempt without NVRAM first. If brcmfmac complains about missing NVRAM, investigate SPROM and extraction options.
+
+---
+
+## 3. CLM Blob (`brcmfmac4360-pcie.clm_blob`)
+
+**Status:** Not investigated
+
+**What CLM provides:**
+Country Locale Matrix — regulatory data specifying allowed channels, power levels, and bandwidth per country. Used by newer brcmfmac firmwares for regulatory compliance.
+
+**Possible sources:**
+- [ ] **Embedded in firmware** — older firmwares (like our 2013 build) may have CLM data built-in rather than as a separate file.
+- [ ] **Extracted from `wl.ko`** — look for CLM signatures in the binary.
+- [ ] **Not needed** — if the firmware predates the CLM split, it won't request one.
+
+**Install path:** `/lib/firmware/brcm/brcmfmac4360-pcie.clm_blob`
+
+**First test plan:** Attempt without CLM. If brcmfmac logs a CLM-related error, investigate extraction.
+
+---
+
+## Test Firmware Layout
+
+For the first test, the `/lib/firmware/brcm/` directory should contain:
+
+```
+/lib/firmware/brcm/
+├── brcmfmac4360-pcie.bin       ← firmware_4352pci.bin (first attempt)
+├── brcmfmac4360-pcie.txt       ← (omit on first test, add if needed)
+└── brcmfmac4360-pcie.clm_blob  ← (omit on first test, add if needed)
+```
+
+Record the exact layout used in each test run under `phase3/results/`.

--- a/phase3/notes/patch_assumptions.md
+++ b/phase3/notes/patch_assumptions.md
@@ -1,0 +1,108 @@
+# Phase 3 Patch Assumptions
+
+**Date:** 2026-04-12
+**Patch:** `phase3/patches/0001-brcmfmac-add-BCM4360-support.patch`
+
+This document tracks the key assumptions made by the proof-of-concept patch, with evidence and verification status.
+
+## Assumption 1: BCM4360 behaves like BCM43602-family chips
+
+**What the patch does:** Groups BCM4360/4352 with the BCM4350/4354/43602 chip family in `chip.c` (shares the same TCM rambase case).
+
+**Evidence for:**
+- Same ARM CR4 CPU core (0x83E), rev 2 vs similar revs in 43602
+- Same PCIe Gen2 core (0x83C)
+- Same BCMA backplane
+- Same ChipCommon core (0x800), rev 43
+- D11 core rev 42 (close to 43602's rev 44)
+
+**Evidence against:**
+- D11 rev 42 vs rev 44 — the wireless core is older, may have init quirks
+- USB 2.0 Device core present (unusual for a PCIe card, may need to be disabled)
+- Firmware version 6.30.223.0 is from 2013, significantly older than typical 43602 firmware
+
+**Status:** ⚠️ UNVERIFIED — plausible but requires runtime test
+
+---
+
+## Assumption 2: TCM RAM base address = 0x180000
+
+**What the patch does:** Falls through to the `0x180000` case in `brcmf_chip_tcm_rambase()`.
+
+**Evidence for:**
+- BCM4350, BCM4354, BCM43602 all use `0x180000`
+- These are all CR4-based PCIe chips in the same family
+- Phase 1.3 analysis concluded this is the likely value
+
+**Evidence against:**
+- Phase 1.1 showed ARM CR4 memory at backplane address `0x00000000` (640KB region) — this is the *local* address, the rambase is the *backplane-mapped* address, but they could differ
+- No direct confirmation from datasheet or runtime probe
+
+**Status:** ⚠️ UNVERIFIED — high confidence but needs runtime confirmation. If wrong, dmesg will show "RAM base not provided" or firmware load to wrong address.
+
+---
+
+## Assumption 3: Firmware name mapping is sufficient
+
+**What the patch does:** Maps chip ID 0x4360 → `brcmfmac4360-pcie` firmware files.
+
+**Evidence for:**
+- Standard brcmfmac naming convention
+- Firmware file placed manually to match
+
+**Evidence against:**
+- The firmware was extracted from `wl.ko`, not provided by Broadcom for brcmfmac use
+- The firmware may expect a different loading sequence or header format (TRX?)
+- The firmware variant selection (4352pci vs 4350pci) is uncertain
+
+**Status:** ⚠️ UNVERIFIED — the name mapping is trivially correct, but whether the firmware *content* is compatible is the real question.
+
+---
+
+## Assumption 4: Firmware uses msgbuf-compatible protocol (version 5-7)
+
+**What the patch does:** Relies on brcmfmac's hardcoded `BRCMF_PROTO_MSGBUF` for PCIe.
+
+**Evidence for:**
+- Firmware contains `pciedev_msg.c` references — this is the dongle side of PCIe message buffering
+- Firmware contains `pciedngl_*` function names — PCIe dongle messaging
+- BCM4360 has the same PCIe Gen2 core as chips that use msgbuf
+
+**Evidence against:**
+- Firmware also contains `bcmcdc.c` references — could indicate BCDC-only protocol
+- Firmware is from 2013; msgbuf may have been introduced later
+- The `bcmcdc.c` reference may indicate BCDC *encapsulation within* msgbuf (normal) or BCDC *instead of* msgbuf (problem)
+
+**Status:** ⚠️ UNVERIFIED — this is the highest-risk assumption. If the firmware writes a protocol version outside 5-7 to shared memory, brcmfmac will reject it. The dmesg output will show the exact version if this fails.
+
+---
+
+## Assumption 5: No chip-specific init quirks needed
+
+**What the patch does:** Adds the chip ID to existing code paths without any BCM4360-specific initialization.
+
+**Evidence for:**
+- Many brcmfmac chips work with just ID additions
+- The core layout is standard
+
+**Evidence against:**
+- BCM43602 has special handling in `brcmf_pcie_enter_download_state()` and `brcmf_pcie_exit_download_state()` for bank power-down and memory core reset
+- The USB 2.0 Device core (unusual for PCIe) may need to be explicitly disabled
+- D11 rev 42 may need different PHY init compared to rev 44
+
+**Status:** ⚠️ UNVERIFIED — likely to be discovered during testing if needed
+
+---
+
+## Verification Plan
+
+All assumptions will be tested simultaneously by loading the patched module. The `dmesg` output will indicate which assumptions hold and which fail:
+
+| Failure message | Assumption invalidated |
+|---|---|
+| "unknown chip" | Chip ID not recognized (patch didn't apply) |
+| "RAM base not provided" | Assumption 2 (TCM rambase) |
+| "firmware: failed to load" | Assumption 3 (firmware mapping/format) |
+| "Unsupported PCIE version N" | Assumption 4 (protocol version) |
+| "Dongle setup failed" | Assumption 5 (init quirks) or Assumption 4 |
+| Interface appears | All assumptions validated for probe stage |

--- a/phase3/notes/testing_instructions.md
+++ b/phase3/notes/testing_instructions.md
@@ -8,12 +8,20 @@
 - `phase3/output/brcmfmac.ko` — main brcmfmac driver with BCM4360/4352 support
 - `phase3/output/brcmfmac-wcc.ko` — WCC firmware vendor module (needed for our chip)
 
-## Kernel Version Note
+## ⚠ Kernel Version Mismatch — Must Fix Before Testing
 
-The module was built against 6.12.80 but the running kernel is 6.12.78. The `insmod` may reject it with a version mismatch. If so, options are:
-1. Force load: `sudo insmod --force brcmfmac.ko` (risky)
-2. Rebuild against the exact running kernel headers
-3. Update NixOS to get 6.12.80 kernel, then test
+The module was built against **6.12.80** but the running kernel is **6.12.78**. This mismatch will cause `insmod` to reject the module. **Do not use `--force`** for initial testing — it introduces avoidable failure modes that confound real results.
+
+**Required:** Rebuild against the exact running kernel before the first test:
+1. Rebuild against the exact running kernel headers (preferred)
+2. Or update NixOS to get 6.12.80 kernel, then test
+
+Verify the module vermagic matches before loading:
+```bash
+modinfo phase3/output/brcmfmac.ko | grep vermagic
+uname -r
+# These must match
+```
 
 ## Pre-test Checklist
 


### PR DESCRIPTION
## Summary

This PR reorganizes the project documentation to reflect completion of Phase 1 reconnaissance and establishes a clear Phase 3 testing plan for patched brcmfmac bring-up. The changes consolidate findings into structured notes and provide explicit verification criteria for the proof-of-concept patch.

## Key Changes

- **Restructured PLAN.md** to reflect current project status:
  - Collapsed Phase 1 findings into a concise completion summary with references to detailed analysis documents
  - Repositioned Phase 2 (MMIO tracing) as a fallback diagnostic tool rather than the primary path
  - Elevated Phase 3 (patched brcmfmac) to the current active phase with detailed sub-tasks and decision criteria

- **Added `phase3/notes/patch_assumptions.md`**:
  - Documents five key assumptions made by the proof-of-concept patch (BCM4360 family grouping, TCM rambase address, firmware naming, msgbuf protocol version, init quirks)
  - Provides evidence for and against each assumption
  - Maps expected failure modes in dmesg to specific invalidated assumptions
  - Establishes verification plan for the first test run

- **Added `phase3/notes/firmware_workstreams.md`**:
  - Tracks three independent firmware components (binary, NVRAM, CLM blob) with separate sourcing and verification status
  - Documents two extracted firmware variants with metadata (size, CRC, build date)
  - Lists open questions for each component (variant selection, TRX header wrapping, regulatory data sourcing)
  - Specifies install paths and first-test fallback strategy

- **Updated `phase3/notes/testing_instructions.md`**:
  - Elevated kernel version mismatch (6.12.80 vs 6.12.78) from a note to a blocking issue with explicit remediation required
  - Added verification command to check module vermagic before loading
  - Clarified that `--force` loading is not acceptable for initial testing

- **Added `phase3/results/.gitkeep`** to establish results directory structure

## Notable Implementation Details

The reorganization emphasizes **assumption-driven testing**: rather than attempting to trace the entire driver initialization, the patch makes five discrete, testable assumptions. The first real test will validate all of them simultaneously via dmesg output, with a clear decision tree for next steps based on which assumptions fail.

The firmware workstreams document acknowledges that the extracted firmware variants are uncertain (4352pci vs 4350pci) and establishes a fallback strategy: test with the most likely variant first, then iterate if needed.

https://claude.ai/code/session_01ViTxf5xyfXyWZXUeSXj5Aj