### PR TITLE
phase6/T269: fw-blob disassembly of pciedngl_isr + wake path

### DIFF
--- a/phase6/t269_add_isr_body.py
+++ b/phase6/t269_add_isr_body.py
@@ -1,0 +1,88 @@
+"""T269: disassemble hndrte_add_isr (0x63C24 — inferred from the
+pcidongle_probe call site at 0x1F28 that passes pciedngl_isr thumb fn-ptr
+0x1C99 as r3). This function wires a software ISR into the scheduler's
+callback list and — we need to discover — may or may not program a HW
+interrupt-mask register.
+
+If hndrte_add_isr programs a HW mask bit, then the scaffold's host-side
+MAILBOXMASK write could be overriding (or racing with) whatever value fw
+has programmed. If hndrte_add_isr does NOT touch HW registers (just builds
+the callback node in TCM), then the HW-enable is done elsewhere.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from t269_disasm import Cs
+
+BLOB = "/home/kimptoc/brcmfmac4360-pcie.bin"
+with open(BLOB, "rb") as f:
+    blob = f.read()
+md = Cs()
+
+
+def u32(off):
+    return int.from_bytes(blob[off:off + 4], "little")
+
+
+def find_fn_end(start, max_scan=0x800):
+    for off in range(start + 4, min(len(blob), start + max_scan), 2):
+        w16 = int.from_bytes(blob[off:off + 2], "little")
+        if w16 == 0xE92D:
+            return off
+        if (w16 & 0xFF00) == 0xB500 and (w16 & 0xFF) != 0:
+            return off
+    return start + max_scan
+
+
+def ascii_str(off, maxlen=80):
+    if not (0 <= off < len(blob)):
+        return None
+    s = []
+    for i in range(maxlen):
+        b = blob[off + i]
+        if b == 0:
+            break
+        if 32 <= b < 127:
+            s.append(chr(b))
+        else:
+            return None
+    return "".join(s) if s else None
+
+
+def dump_range(start, end, label, max_lines=300):
+    print(f"\n=== {label} 0x{start:X}..0x{end:X} ===")
+    i = 0
+    for ins in md.disasm(blob[start:end], start):
+        extra = ""
+        if "pc," in ins.op_str and ins.mnemonic.startswith("ldr"):
+            try:
+                imm_str = ins.op_str.split("#")[-1].strip().rstrip("]")
+                imm = int(imm_str, 16) if "0x" in imm_str else int(imm_str)
+                lit = ((ins.address + 4) & ~3) + imm
+                if lit + 4 <= len(blob):
+                    v = u32(lit)
+                    s = ascii_str(v)
+                    note = f'="{s}"' if s and len(s) > 2 else ""
+                    extra = f"  ; lit@0x{lit:06X}=0x{v:08X}{note}"
+            except Exception:
+                pass
+        print(f"  0x{ins.address:06X}: {ins.mnemonic:<10} {ins.op_str}{extra}")
+        i += 1
+        if i > max_lines:
+            break
+
+
+# 1. hndrte_add_isr body
+end = find_fn_end(0x63C24, 0xC00)
+dump_range(0x63C24, end, "hndrte_add_isr (0x63C24)")
+
+# 2. The deadman/trap handler dumper at 0x63EE4 (prev fn before deadman_to ref)
+end2 = find_fn_end(0x63EE4, 0x400)
+dump_range(0x63EE4, end2, "deadman trap-dump handler (0x63EE4)")
+
+# 3. idle-loop WFI thunks
+print("\n=== 0x1C0C WFI thunk / 0x1C10 0x1C1C ===")
+for start in (0x1C0C, 0x1C10, 0x1C1C, 0x1C1E):
+    end = find_fn_end(start, 0x20)
+    dump_range(start, end, f"fn@0x{start:X}", max_lines=10)

--- a/phase6/t269_disasm.py
+++ b/phase6/t269_disasm.py
@@ -1,0 +1,82 @@
+"""Minimal capstone wrapper via ctypes — the nix Python env used in prior
+phase5 scripts is gone, but libcapstone.so is installed and accessible via
+ctypes from the system Python. Only the bits we need for static Thumb
+disassembly are exposed here.
+"""
+import ctypes
+import ctypes.util
+
+CS_ARCH_ARM = 0
+CS_MODE_THUMB = 1 << 4
+CS_ERR_OK = 0
+
+_LIB = "/nix/store/w0i5kgw8zhdimryqm78mmydz6kiddy63-capstone-5.0.7/lib/libcapstone.so.5"
+_cs = ctypes.CDLL(_LIB)
+
+
+class _CsInsn(ctypes.Structure):
+    _fields_ = [
+        ("id", ctypes.c_uint),
+        ("address", ctypes.c_uint64),
+        ("size", ctypes.c_uint16),
+        ("bytes", ctypes.c_ubyte * 24),
+        ("mnemonic", ctypes.c_char * 32),
+        ("op_str", ctypes.c_char * 160),
+        ("detail", ctypes.c_void_p),
+    ]
+
+
+_cs.cs_open.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.POINTER(ctypes.c_size_t)]
+_cs.cs_open.restype = ctypes.c_int
+_cs.cs_close.argtypes = [ctypes.POINTER(ctypes.c_size_t)]
+_cs.cs_close.restype = ctypes.c_int
+_cs.cs_disasm.argtypes = [
+    ctypes.c_size_t,
+    ctypes.c_char_p,
+    ctypes.c_size_t,
+    ctypes.c_uint64,
+    ctypes.c_size_t,
+    ctypes.POINTER(ctypes.POINTER(_CsInsn)),
+]
+_cs.cs_disasm.restype = ctypes.c_size_t
+_cs.cs_free.argtypes = [ctypes.POINTER(_CsInsn), ctypes.c_size_t]
+
+
+class Insn:
+    __slots__ = ("address", "size", "mnemonic", "op_str", "bytes")
+
+    def __init__(self, i):
+        self.address = i.address
+        self.size = i.size
+        self.mnemonic = i.mnemonic.decode("ascii", "replace")
+        self.op_str = i.op_str.decode("ascii", "replace")
+        self.bytes = bytes(i.bytes[: i.size])
+
+
+class Cs:
+    def __init__(self, arch=CS_ARCH_ARM, mode=CS_MODE_THUMB):
+        self.h = ctypes.c_size_t(0)
+        rc = _cs.cs_open(arch, mode, ctypes.byref(self.h))
+        if rc != CS_ERR_OK:
+            raise RuntimeError(f"cs_open failed rc={rc}")
+
+    def __del__(self):
+        try:
+            _cs.cs_close(ctypes.byref(self.h))
+        except Exception:
+            pass
+
+    def disasm(self, data, addr, count=0):
+        buf = (ctypes.c_char * len(data)).from_buffer_copy(data)
+        arr = ctypes.POINTER(_CsInsn)()
+        n = _cs.cs_disasm(self.h, buf, len(data), addr, count, ctypes.byref(arr))
+        out = [Insn(arr[i]) for i in range(n)]
+        if n:
+            _cs.cs_free(arr, n)
+        return out
+
+
+if __name__ == "__main__":
+    md = Cs()
+    for ins in md.disasm(b"\x70\x47", 0):
+        print(f"0x{ins.address:X}: {ins.mnemonic} {ins.op_str}")

--- a/phase6/t269_disasm.py
+++ b/phase6/t269_disasm.py
@@ -5,12 +5,42 @@ disassembly are exposed here.
 """
 import ctypes
 import ctypes.util
+import glob
+import os
 
 CS_ARCH_ARM = 0
 CS_MODE_THUMB = 1 << 4
 CS_ERR_OK = 0
 
-_LIB = "/nix/store/w0i5kgw8zhdimryqm78mmydz6kiddy63-capstone-5.0.7/lib/libcapstone.so.5"
+
+def _find_libcapstone():
+    # 1. Honour an explicit override.
+    env = os.environ.get("LIBCAPSTONE")
+    if env and os.path.exists(env):
+        return env
+    # 2. Standard ctypes lookup (ldconfig / LD_LIBRARY_PATH).
+    name = ctypes.util.find_library("capstone")
+    if name:
+        return name
+    # 3. Common FHS paths.
+    for cand in (
+        "/usr/lib/x86_64-linux-gnu/libcapstone.so.5",
+        "/usr/lib/libcapstone.so.5",
+        "/usr/local/lib/libcapstone.so.5",
+    ):
+        if os.path.exists(cand):
+            return cand
+    # 4. Nix store fallback (this host's setup — glob any matching derivation
+    #    instead of pinning a single hash so a GC sweep + rebuild doesn't break).
+    for cand in sorted(glob.glob("/nix/store/*capstone*/lib/libcapstone.so.5")):
+        return cand
+    raise RuntimeError(
+        "libcapstone.so not found. Set LIBCAPSTONE=/path/to/libcapstone.so.5 "
+        "or install capstone via your system package manager."
+    )
+
+
+_LIB = _find_libcapstone()
 _cs = ctypes.CDLL(_LIB)
 
 

--- a/phase6/t269_hndrte_add_isr.py
+++ b/phase6/t269_hndrte_add_isr.py
@@ -1,0 +1,152 @@
+"""T269: find hndrte_add_isr callers / body and the fault-handler that prints
+the deadman_to register dump. Understanding hndrte_add_isr tells us HOW a
+software flag bit (0x8 for pciedngl_isr) gets mapped to a hardware interrupt
+source — which is the central question for "which HW bit wakes the ISR".
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from t269_disasm import Cs
+
+BLOB = "/home/kimptoc/brcmfmac4360-pcie.bin"
+with open(BLOB, "rb") as f:
+    blob = f.read()
+md = Cs()
+
+
+def u32(off):
+    return int.from_bytes(blob[off:off + 4], "little")
+
+
+def find_lit_exact(val):
+    p = val.to_bytes(4, "little")
+    out = []
+    pos = 0
+    while True:
+        h = blob.find(p, pos)
+        if h < 0:
+            break
+        out.append(h)
+        pos = h + 1
+    return out
+
+
+def find_prev_fn(addr, max_back=0x400):
+    for off in range(addr, max(0, addr - max_back), -2):
+        w16 = int.from_bytes(blob[off:off + 2], "little")
+        if w16 == 0xE92D:
+            return off
+        if (w16 & 0xFF00) == 0xB500 and (w16 & 0xFF) != 0:
+            return off
+    return None
+
+
+def find_fn_end(start, max_scan=0x600):
+    for off in range(start + 4, min(len(blob), start + max_scan), 2):
+        w16 = int.from_bytes(blob[off:off + 2], "little")
+        if w16 == 0xE92D:
+            return off
+        if (w16 & 0xFF00) == 0xB500 and (w16 & 0xFF) != 0:
+            return off
+    return start + max_scan
+
+
+def scan_lit_pool(addr_val):
+    """Find blob offsets where the 4-byte little-endian addr_val literal lives."""
+    return find_lit_exact(addr_val)
+
+
+def dump_range(start, end, label, max_lines=120):
+    print(f"\n=== {label} 0x{start:X}..0x{end:X} ===")
+    i = 0
+    for ins in md.disasm(blob[start:end], start):
+        extra = ""
+        if "pc," in ins.op_str and ins.mnemonic.startswith("ldr"):
+            try:
+                imm_str = ins.op_str.split("#")[-1].strip().rstrip("]")
+                imm = int(imm_str, 16) if "0x" in imm_str else int(imm_str)
+                lit = ((ins.address + 4) & ~3) + imm
+                if lit + 4 <= len(blob):
+                    v = u32(lit)
+                    extra = f"  ; lit@0x{lit:06X}=0x{v:08X}"
+                    # annotate
+                    if 0x40000 <= v < 0x6C000:
+                        s_end = v
+                        while s_end < len(blob) and blob[s_end] != 0 and 32 <= blob[s_end] < 127:
+                            s_end += 1
+                        if s_end > v + 2:
+                            try:
+                                extra += f' "{blob[v:s_end].decode("ascii")}"'
+                            except Exception:
+                                pass
+            except Exception:
+                pass
+        print(f"  0x{ins.address:06X}: {ins.mnemonic:<10} {ins.op_str}{extra}")
+        i += 1
+        if i > max_lines:
+            break
+
+
+# Find "hndrte_add_isr failed" string and the function that uses it
+ADD_ISR_MSG = b"pcidongle_probe:hndrte_add_isr failed"
+h = blob.find(ADD_ISR_MSG)
+print(f"pcidongle_probe err string @ 0x{h:06X}")
+# find what references it
+refs = find_lit_exact(h)
+print(f"  literal refs to 0x{h:06X}: {refs}")
+for r in refs[:5]:
+    # back up to find function prologue
+    fn = find_prev_fn(r, max_back=0x800)
+    print(f"    ref@0x{r:06X}  containing_fn_prologue=0x{fn:06X}")
+
+# Find where the node[0] fn-ptr value 0x1C99 (thumb) appears — this is the
+# hndrte_add_isr call site literal
+print("\n=== References to 0x1C99 (pciedngl_isr thumb fn-ptr) ===")
+for h in find_lit_exact(0x1C99):
+    fn = find_prev_fn(h)
+    print(f"  lit@0x{h:06X}  prev-fn-prologue=0x{fn if fn else -1:06X}")
+
+# Find where "pciedngldev" string (arg of ISR) is referenced as a literal
+print("\n=== References to 0x58CC4 (pciedev struct 'pciedngldev') ===")
+for h in find_lit_exact(0x58CC4):
+    fn = find_prev_fn(h)
+    print(f"  lit@0x{h:06X}  prev-fn-prologue=0x{fn if fn else -1:06X}")
+
+# Where is "deadman_to" referenced?
+print("\n=== References to 'deadman_to' string (0x40659) ===")
+for h in find_lit_exact(0x40659):
+    fn = find_prev_fn(h, max_back=0x1000)
+    print(f"  lit@0x{h:06X}  prev-fn-prologue=0x{fn if fn else -1:06X}")
+
+# Where is "ramstbydis" (0x4067A)? Looks like a standby-disable word
+print("\n=== References to 'ramstbydis' string (0x4067A) ===")
+for h in find_lit_exact(0x4067A):
+    fn = find_prev_fn(h, max_back=0x400)
+    print(f"  lit@0x{h:06X}  prev-fn-prologue=0x{fn if fn else -1:06X}")
+
+# Disassemble the function that owns the pcidongle_probe error reference
+print("\n=== Disasm of function that prints hndrte_add_isr failed ===")
+if refs:
+    # Take the first ref; find the function containing it
+    ref = refs[0]
+    # find a reasonable window: previous push prologue back up, then to end
+    fn_start = None
+    # scan back looking for push.w or short push
+    for off in range(ref, max(0, ref - 0x200), -2):
+        w16 = int.from_bytes(blob[off:off + 2], "little")
+        if w16 == 0xE92D:
+            fn_start = off
+            break
+        if (w16 & 0xFF00) == 0xB500 and (w16 & 0xFF) != 0:
+            fn_start = off
+            break
+    if fn_start:
+        end = find_fn_end(fn_start)
+        print(f"Function @ 0x{fn_start:06X}..0x{end:06X}")
+        dump_range(fn_start, end, "pcidongle_probe fragment", max_lines=200)
+
+# Separately: disassemble 0x115C (scheduler body) to capture the
+# event-mask test pattern (r5 = bl 0x9936; tst r5, flag).
+print("\n=== Scheduler @ 0x115C..0x11E0 (event-dispatch loop) ===")
+dump_range(0x115C, 0x11F0, "scheduler-0x115C", max_lines=60)

--- a/phase6/t269_hw_enable.py
+++ b/phase6/t269_hw_enable.py
@@ -1,0 +1,113 @@
+"""T269: dig into
+- 0x99AC (called at end of hndrte_add_isr — likely HW-unmask commit)
+- 0x9940 / 0x9944 / 0x9956 / 0x9990 (scheduler-bit-index helpers used to
+  compute the 1<<n flag for the new node)
+- 0x1A8C (the deadman-timer callback, whose ptr sits at 0x63F72 ref'd from
+  the init code around deadman_to string)
+- The exception / trap dumper that prints 'r11 %x, r12 %x' (0x40600) — this
+  is the saved-state dumper when a fault occurs.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from t269_disasm import Cs
+
+BLOB = "/home/kimptoc/brcmfmac4360-pcie.bin"
+with open(BLOB, "rb") as f:
+    blob = f.read()
+md = Cs()
+
+
+def u32(off):
+    return int.from_bytes(blob[off:off + 4], "little")
+
+
+def find_lit_exact(val):
+    p = val.to_bytes(4, "little")
+    out = []
+    pos = 0
+    while True:
+        h = blob.find(p, pos)
+        if h < 0:
+            break
+        out.append(h)
+        pos = h + 1
+    return out
+
+
+def find_fn_end(start, max_scan=0x800):
+    for off in range(start + 4, min(len(blob), start + max_scan), 2):
+        w16 = int.from_bytes(blob[off:off + 2], "little")
+        if w16 == 0xE92D:
+            return off
+        if (w16 & 0xFF00) == 0xB500 and (w16 & 0xFF) != 0:
+            return off
+    return start + max_scan
+
+
+def ascii_str(off, maxlen=80):
+    if not (0 <= off < len(blob)):
+        return None
+    s = []
+    for i in range(maxlen):
+        b = blob[off + i]
+        if b == 0:
+            break
+        if 32 <= b < 127:
+            s.append(chr(b))
+        else:
+            return None
+    return "".join(s) if s else None
+
+
+def dump_range(start, end, label, max_lines=100):
+    print(f"\n=== {label} 0x{start:X}..0x{end:X} ===")
+    i = 0
+    for ins in md.disasm(blob[start:end], start):
+        extra = ""
+        if "pc," in ins.op_str and ins.mnemonic.startswith("ldr"):
+            try:
+                imm_str = ins.op_str.split("#")[-1].strip().rstrip("]")
+                imm = int(imm_str, 16) if "0x" in imm_str else int(imm_str)
+                lit = ((ins.address + 4) & ~3) + imm
+                if lit + 4 <= len(blob):
+                    v = u32(lit)
+                    s = ascii_str(v)
+                    note = f'="{s}"' if s and len(s) > 2 else ""
+                    extra = f"  ; lit@0x{lit:06X}=0x{v:08X}{note}"
+            except Exception:
+                pass
+        print(f"  0x{ins.address:06X}: {ins.mnemonic:<10} {ins.op_str}{extra}")
+        i += 1
+        if i > max_lines:
+            break
+
+
+for start, label in [
+    (0x99AC, "hndrte_add_isr tail call (0x99AC, HW unmask?)"),
+    (0x9940, "sched bit index helper (0x9940)"),
+    (0x9944, "sched bit index helper (0x9944)"),
+    (0x9956, "sched helper (0x9956, called near entry of add_isr)"),
+    (0x9990, "sched helper (0x9990, name/id lookup)"),
+    (0x9A32, "sched helper (0x9A32, called inside deadman init)"),
+    (0x1A8C, "deadman callback (fn-ptr 0x1A8D)"),
+    (0x1BA4, "deadman 0x1BA5 callback helper"),
+    (0x1298, "small-alloc wrapper (0x1298)"),
+]:
+    end = find_fn_end(start, 0x200)
+    dump_range(start, end, label, max_lines=50)
+
+# Fault/trap dump handler — find where 'r11 %x, r12 %x' is referenced.
+print("\n=== refs to 'r11 %x, r12 %x' (0x40600) ===")
+for h in find_lit_exact(0x40600):
+    print(f"  lit@0x{h:06X}")
+
+# Search for trap/exception vector writes — the exception vectors start near
+# address 0 typically (reset, undef, swi, prefetch_abt, data_abt, irq, fiq).
+# On CortexR-like Broadcom fw, the vector may be at 0x0 or remapped.
+# Just print the first 0x80 bytes of the blob for vector table inspection.
+print("\n=== Blob[0..0x80] vector table region ===")
+for off in range(0, 0x80, 4):
+    v = u32(off)
+    print(f"  0x{off:02X}: 0x{v:08X}")

--- a/phase6/t269_isr_prologue.py
+++ b/phase6/t269_isr_prologue.py
@@ -1,0 +1,112 @@
+"""T269 step 1+2: disasm pciedngl_isr (node[0].fn = 0x1C98) and 0x9936.
+
+node[0] values captured at runtime via T256 TCM BAR2 probe:
+  next = 0x96F48, fn = 0x1C99 (Thumb → entry 0x1C98), arg = 0x58CC4, flag = 0x08
+
+String evidence confirms 0x1C98 = pciedngl_isr:
+  blob[0x4069D] = "pciedngl_isr called\n"
+  blob[0x406B2] = "%s: invalid ISR status: 0x%08x"
+  blob[0x40685] = "pciedngl_isr"
+  blob[0x406E5] = "pciedev_msg.c"
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from t269_disasm import Cs
+
+BLOB = "/home/kimptoc/brcmfmac4360-pcie.bin"
+with open(BLOB, "rb") as f:
+    blob = f.read()
+
+md = Cs()
+
+
+def u32(off):
+    return int.from_bytes(blob[off:off + 4], "little")
+
+
+def find_fn_end(start, max_scan=0x600):
+    """End of function = start of next function prologue (push stub)."""
+    for off in range(start + 4, min(len(blob), start + max_scan), 2):
+        w16 = int.from_bytes(blob[off:off + 2], "little")
+        if w16 == 0xE92D:
+            return off
+        if (w16 & 0xFF00) == 0xB500 and (w16 & 0xFF) != 0:
+            return off
+    return start + max_scan
+
+
+def ascii_str(off, maxlen=64):
+    s = []
+    for i in range(maxlen):
+        b = blob[off + i]
+        if b == 0:
+            break
+        if 32 <= b < 127:
+            s.append(chr(b))
+        else:
+            return None
+    return "".join(s) if s else None
+
+
+def is_reg_base(v):
+    """Is v a plausible SoC MMIO base?"""
+    bases = [
+        (0x18000000, 0x19000000, "backplane"),
+        (0x18000000, 0x18100000, "SB core window"),
+    ]
+    for lo, hi, desc in bases:
+        if lo <= v < hi:
+            return desc
+    return None
+
+
+def dump_fn(addr, label, count=100, show_literals=True):
+    end = find_fn_end(addr)
+    print(f"=== {label} @ 0x{addr:X} ..0x{end:X} ({end - addr} bytes, ~{(end-addr)//2} halfwords) ===")
+    n = 0
+    for ins in md.disasm(blob[addr:end], addr):
+        extra = ""
+        if show_literals and "pc," in ins.op_str:
+            try:
+                imm_str = ins.op_str.split("#")[-1].strip().rstrip("]")
+                imm = int(imm_str, 16) if "0x" in imm_str else int(imm_str)
+                lit = ((ins.address + 4) & ~3) + imm
+                if lit + 4 <= len(blob):
+                    val = u32(lit)
+                    note = ""
+                    s = ascii_str(val) if 0 <= val < len(blob) else None
+                    if s:
+                        note = f' str="{s}"'
+                    elif (rb := is_reg_base(val)):
+                        note = f" ({rb})"
+                    elif 0x80000 <= val < 0xA0000:
+                        note = " (TCM BSS/heap)"
+                    elif 0x40000 <= val < 0x70000:
+                        note = " (blob data)"
+                    elif val < 0x6C000:
+                        ns = ascii_str(val)
+                        if ns:
+                            note = f' str="{ns}"'
+                    extra = f"  ; lit@0x{lit:06X}=0x{val:08X}{note}"
+            except Exception:
+                pass
+        print(f"  0x{ins.address:06X}: {ins.mnemonic:<10} {ins.op_str}{extra}")
+        n += 1
+        if n >= count:
+            break
+    return end
+
+
+print("=" * 72)
+dump_fn(0x1C98, "pciedngl_isr", count=200)
+print()
+print("=" * 72)
+dump_fn(0x9936, "scheduler-event-mask-source", count=40)
+print()
+print("=" * 72)
+print("Node[0].arg = 0x58CC4 dereferenced:")
+print(f"  u32@0x58CC4 = 0x{u32(0x58CC4):08X}")
+print(f"  ASCII: {ascii_str(0x58CC4)!r}")
+print(f"  Hex bytes: {blob[0x58CC4:0x58CC4+64].hex(' ', 4)}")

--- a/phase6/t269_locate_isr.py
+++ b/phase6/t269_locate_isr.py
@@ -1,0 +1,96 @@
+"""T269 step 1: walk scheduler callback list to locate pciedngl_isr (node[0]).
+
+Prior T254/T256 work: scheduler at 0x115C walks a linked list headed at
+[0x629A4] with per-node layout (from T254 §7 read of the scheduler loop):
+
+  +0x0  next
+  +0x4  fn-ptr (Thumb, LSB=1)
+  +0x8  arg
+  +0xC  flag (tested with scheduler r5 = bl 0x9936 return value)
+
+Blob maps to both flash base 0 (for code) and TCM at runtime; for static
+analysis we treat the file offset == load address, so BSS data values at
+offsets like 0x629A4 read directly.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from t269_disasm import Cs
+
+BLOB = "/home/kimptoc/brcmfmac4360-pcie.bin"
+with open(BLOB, "rb") as f:
+    blob = f.read()
+
+md = Cs()
+
+
+def u32(off):
+    return int.from_bytes(blob[off:off + 4], "little")
+
+
+LIST_HEAD = 0x629A4
+print(f"List head @ 0x{LIST_HEAD:X} = 0x{u32(LIST_HEAD):08X}")
+print(f"Current-task ptr @ 0x6299C = 0x{u32(0x6299C):08X}")
+print(f"Sleep-flag @ 0x629B4 = 0x{u32(0x629B4):08X}")
+
+print("\n=== Walk list ===")
+node = u32(LIST_HEAD)
+seen = set()
+i = 0
+nodes = []
+while node and node not in seen and i < 32:
+    seen.add(node)
+    nxt = u32(node + 0x0)
+    fn = u32(node + 0x4)
+    arg = u32(node + 0x8)
+    flag = u32(node + 0xC)
+    print(f"node[{i}] @ 0x{node:06X}:")
+    print(f"  next  = 0x{nxt:08X}")
+    print(f"  fn    = 0x{fn:08X}   (entry=0x{(fn & ~1):06X}, thumb={'yes' if fn & 1 else 'no'})")
+    print(f"  arg   = 0x{arg:08X}")
+    print(f"  flag  = 0x{flag:08X}")
+    nodes.append((node, fn & ~1, arg, flag))
+    node = nxt
+    i += 1
+print(f"Total nodes: {i}")
+
+if not nodes:
+    print("\nList head is zero in blob image. Checking for nearby pointers...")
+    for off in range(0x62900, 0x62A00, 4):
+        v = u32(off)
+        if 0x50000 <= v < 0xA0000:
+            print(f"  0x{off:05X} -> 0x{v:08X}")
+    sys.exit(0)
+
+# Prologue check: each node[0..].fn entry.
+print("\n=== Prologue scan for each node.fn ===")
+for idx, (_, fn, _, _) in enumerate(nodes):
+    first = int.from_bytes(blob[fn:fn + 2], "little")
+    first4 = int.from_bytes(blob[fn:fn + 4], "little")
+    is_push_short = (first & 0xFF00) == 0xB500 and (first & 0xFF) != 0
+    is_push_wide = (first4 & 0xFFFF) == 0xE92D
+    is_push = is_push_short or is_push_wide
+    print(f"  node[{idx}] fn=0x{fn:06X} first2=0x{first:04X} push-like? {is_push}")
+
+# Disassemble node[0] fn prologue (~60 insns).
+print("\n=== pciedngl_isr (node[0]) prologue — first 60 insns ===")
+fn = nodes[0][1]
+n = 0
+for ins in md.disasm(blob[fn:fn + 0x180], fn):
+    lit_str = ""
+    if ins.mnemonic.startswith("ldr") and "pc," in ins.op_str:
+        # ldr rX, [pc, #imm] form
+        try:
+            imm_str = ins.op_str.split("#")[-1].strip().rstrip("]")
+            imm = int(imm_str, 16) if imm_str.startswith("0x") else int(imm_str)
+            lit = ((ins.address + 4) & ~3) + imm
+            if lit + 4 <= len(blob):
+                val = int.from_bytes(blob[lit:lit + 4], "little")
+                lit_str = f"  ; lit@0x{lit:06X} = 0x{val:08X}"
+        except Exception:
+            pass
+    print(f"  0x{ins.address:06X}: {ins.mnemonic:<8} {ins.op_str}{lit_str}")
+    n += 1
+    if n >= 60:
+        break

--- a/phase6/t269_mailbox_search.py
+++ b/phase6/t269_mailbox_search.py
@@ -85,7 +85,8 @@ for label, val in [
     ("MAILBOXINT offset", 0x00000048),
     ("MAILBOXMASK offset", 0x0000004C),
     ("BRCMF_H2D_HOST_D3_INFORM", 0x00000001),  # noisy but worth locating
-    ("BRCMF_PCIE_SHARED_HOSTRDY_DB1 bit", 0x20000000),  # conventional
+    # Upstream bcmfmac: pcie.c:1016 #define BRCMF_PCIE_SHARED_HOSTRDY_DB1 0x10000000
+    ("BRCMF_PCIE_SHARED_HOSTRDY_DB1 bit", 0x10000000),
 ]:
     hits = find_lit_exact(val)
     label_n = min(20, len(hits))

--- a/phase6/t269_mailbox_search.py
+++ b/phase6/t269_mailbox_search.py
@@ -1,0 +1,146 @@
+"""T269 steps 3-5: search blob for mailbox-register literals, our MAILBOXMASK
+value, and host-ready / watchdog-related patterns.
+
+Reasoning for literal search:
+- Fw accesses HW registers via backplane addresses. The PCIe Gen2 core window
+  on a BCM4360 backplane typically sits at 0x18003000-0x18007000. If the fw's
+  ISR_STATUS register read is MMIO, it'll use one of these bases + offset 0x48
+  (MAILBOXINT) or 0x4C (MAILBOXMASK). Scanning for nearby literals catches it.
+- Our driver writes MAILBOXMASK = 0x00FF0300 and H2D_MAILBOX_1 = 1. If fw polls
+  MAILBOXMASK itself to verify host-ready, literal 0x00FF0300 would appear.
+- "Panic" / "reboot" strings in blob indicate fw watchdog handlers.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from t269_disasm import Cs
+
+BLOB = "/home/kimptoc/brcmfmac4360-pcie.bin"
+with open(BLOB, "rb") as f:
+    blob = f.read()
+md = Cs()
+
+
+def u32(off):
+    return int.from_bytes(blob[off:off + 4], "little")
+
+
+def find_lits(lo, hi):
+    """Return (blob_offset, value) for any u32 in [lo, hi) found in blob."""
+    hits = []
+    for off in range(0, len(blob) - 4, 4):
+        v = u32(off)
+        if lo <= v < hi:
+            hits.append((off, v))
+    return hits
+
+
+def find_lit_exact(val):
+    p = val.to_bytes(4, "little")
+    out = []
+    pos = 0
+    while True:
+        h = blob.find(p, pos)
+        if h < 0:
+            break
+        out.append(h)
+        pos = h + 1
+    return out
+
+
+def find_strings(needle):
+    pos = 0
+    out = []
+    while True:
+        h = blob.find(needle, pos)
+        if h < 0:
+            break
+        out.append(h)
+        pos = h + 1
+    return out
+
+
+print("=== MMIO base literals: PCIe core window candidates ===")
+# BCM4360 backplane: ChipCommon 0x18001000, PMU 0x18000000, PCIe Gen2 core ~ 0x18003000
+# Scan for any 0x1800xxxx literal and cluster by base.
+from collections import Counter
+hits = find_lits(0x18000000, 0x1A000000)
+print(f"{len(hits)} literals in 0x18000000-0x1A000000 range. Bases by top-16 bits:")
+bases = Counter((h[1] & 0xFFFFF000) for h in hits)
+for base, n in sorted(bases.items()):
+    print(f"  0x{base:08X}: {n} occurrences")
+print()
+
+# Specific literals tied to our scaffold
+print("=== Specific scaffold literals ===")
+for label, val in [
+    ("MAILBOXMASK value (our scaffold)", 0x00FF0300),
+    ("MAILBOXMASK low bits FN0_only", 0x00000300),
+    ("MAILBOXMASK d2h_db only", 0x00FF0000),
+    ("MB_INT_FN0_0 bit", 0x00000100),
+    ("MB_INT_FN0_1 bit", 0x00000200),
+    ("H2D_MAILBOX_1 offset", 0x00000144),
+    ("H2D_MAILBOX_0 offset", 0x00000140),
+    ("MAILBOXINT offset", 0x00000048),
+    ("MAILBOXMASK offset", 0x0000004C),
+    ("BRCMF_H2D_HOST_D3_INFORM", 0x00000001),  # noisy but worth locating
+    ("BRCMF_PCIE_SHARED_HOSTRDY_DB1 bit", 0x20000000),  # conventional
+]:
+    hits = find_lit_exact(val)
+    label_n = min(20, len(hits))
+    print(f"  {label} (0x{val:08X}): {len(hits)} raw hits")
+    for h in hits[:label_n]:
+        ctx = ""
+        if 0 <= h < len(blob) - 16:
+            ctx = blob[max(0, h - 4):h + 8].hex(" ", 4)
+        print(f"    @0x{h:06X}  ctx={ctx}")
+print()
+
+# Strings of interest
+print("=== Strings related to ISR/handshake/watchdog ===")
+for s in [
+    b"pciedngl_isr",
+    b"mailbox",
+    b"MAILBOX",
+    b"hostready",
+    b"HostReady",
+    b"D2H_DB",
+    b"pending",
+    b"intstatus",
+    b"watchdog",
+    b"panic",
+    b"reboot",
+    b"reset",
+    b"invalid ISR",
+    b"pciedngl_",
+    b"pciedev",
+    b"hnd_msg",
+    b"_rte",
+    b"sb_cc",
+    b"ci_attach",
+    b"doorbell",
+    b"interrupt",
+    b"IntStatus",
+    b"D2H",
+    b"H2D",
+    b"dongle",
+]:
+    hits = find_strings(s)
+    n = len(hits)
+    if n == 0:
+        continue
+    print(f"  {s!r}: {n} hits")
+    for h in hits[:5]:
+        # show the surrounding null-terminated string
+        start = h
+        while start > 0 and blob[start - 1] != 0 and (blob[start - 1] >= 32 and blob[start - 1] < 127):
+            start -= 1
+        end = h
+        while end < len(blob) and blob[end] != 0 and (blob[end] >= 32 and blob[end] < 127):
+            end += 1
+        try:
+            label = blob[start:end].decode("ascii", "replace")
+        except Exception:
+            label = "<decode-err>"
+        print(f"    @0x{h:06X}  <{label}>")

--- a/phase6/t269_pciedngl_isr.md
+++ b/phase6/t269_pciedngl_isr.md
@@ -1,0 +1,201 @@
+# T269 — Firmware-blob disassembly of `pciedngl_isr` and the wake path
+
+**Date:** 2026-04-24
+**Blob:** `/home/kimptoc/brcmfmac4360-pcie.bin` (442233 bytes, md5 `812705b3ff0f81f0ef067f6a42ba7b46`)
+**Method:** Read-only static disassembly with capstone via ctypes (Thumb mode). Scripts alongside this doc.
+**Task brief:** `phase6/t269_fw_blob_diss.md`
+**Clean-room note:** all observations are described in plain language from disassembled mnemonics, literal-pool reads, and ASCII-string cross-references. No large reconstructed function bodies committed — only short illustrative snippets where essential.
+
+## TL;DR
+
+- `pciedngl_isr` entry confirmed at blob **0x1C98** (Thumb). Body is 260 bytes.
+- Scheduler dispatches it whenever bit **3 (0x8)** of the RTE "pending events" word is set. That word lives at `*(*(ctx+0x358)+0x100)` where `ctx = [0x6296C]`; the bit-index is allocated at registration time by `hndrte_add_isr` (not hard-coded).
+- The ISR reads a software ISR_STATUS at `*(pciedev+0x18)+0x18)+0x20` and tests **bit 0x100** (which matches upstream's `BRCMF_PCIE_MB_INT_FN0_0` bit — the FN0 doorbell triggered by a host write to `H2D_MAILBOX_1`). On valid, it ACKs by writing 0x100 back (W1C).
+- Fw performs **no host-facing register write** as part of its wake handshake. All response is via TCM ring writes that the host polls.
+- `hndrte_add_isr` tail-calls a **HW-unmask commit** (0x99AC → 0x27EC) that enables the bit for the CPU only *after* the scheduler list is populated.
+- **No "panic" / "reboot" string** in the blob. The fault-dump handler (0x63EE4) installs a software "deadman_to" RTE timer, but it is an internal PM / ramstbydis timer, not a "host didn't respond" kill-switch.
+- **Upstream brcmfmac's normal order** is: fw publishes `shared.flags |= BRCMF_PCIE_SHARED_HOSTRDY_DB1` (0x10000000), and only *then* does the host call `brcmf_pcie_hostready` (write H2D_MAILBOX_1 = 1). Our scaffold rings the doorbell without waiting for that flag — so when fw wakes, it runs `pciedngl_isr` against un-initialized ring state, which is consistent with the silent late-ladder wedge.
+
+## 1. pciedngl_isr entry point confirmation
+
+T256 captured the scheduler callback list from live TCM via BAR2 probes:
+
+```
+node[0] @ 0x9627C:
+  next = 0x96F48     fn = 0x1C99 (Thumb → 0x1C98)
+  arg  = 0x58CC4     flag = 0x00000008
+```
+
+Disassembly at 0x1C98 has a 7-register save prologue (`push.w {r4-r8, sb, lr}`) and immediately references three blob strings that confirm the identity:
+
+| Blob offset | String |
+|---|---|
+| 0x4069D | `"pciedngl_isr called\n"` |
+| 0x406B2 | `"%s: invalid ISR status: 0x%08x"` |
+| 0x40685 | `"pciedngl_isr"` |
+| 0x406E5 | `"pciedev_msg.c"` |
+| 0x40733 | `"pciedngl_isr exits"` |
+
+These are referenced from 0x1CA0, 0x1CB6, 0x1CB8, 0x1CDC, 0x1D70 — i.e. they are used by this function, not just colocated. **Identity settled.**
+
+Script: `phase6/t269_locate_isr.py` (walks [0x629A4] if populated, verifies prologue at 0x1C98). Note: the list head is zero in the blob image — the list is built at runtime by pcidongle_probe, so static list-walking produces no nodes; the captured TCM values from T256 are what we trust.
+
+## 2. How the scheduler picks node[0]
+
+The RTE scheduler at 0x115C walks the callback list:
+
+- `r0 = *[0x6296C]` (the interrupt-class context pointer).
+- `r5 = bl 0x9936` — event-mask getter. This is a 3-insn leaf: `r3 = [r0+0x358]; r0 = [r3+0x100]; bx lr`. So `r5 = *(*(ctx+0x358)+0x100)` — a software-maintained 32-bit "pending events" word.
+- Iterate nodes starting at `*[0x629A4]`. For each node:
+  - `r3 = node.flag (+0xC)`
+  - `tst r5, r3` — check if any of the node's bits are pending
+  - if set, `r3 = node.fn (+4)`, `r0 = node.arg (+8)`, `blx r3`
+
+Node[0].flag = 0x8, so bit 3 of the pending word dispatches `pciedngl_isr`.
+
+`0x9936` is a **reader** only (no side effects, no BSS writes — confirmed also by T256 prechecks). The pending word is populated by the HW-interrupt dispatcher, which we did not chase further (its writer lives inside the RTE IRQ entry path that branches through the 0x28xx table — cf. `0x99AC b.w 0x27EC` below).
+
+## 3. pciedngl_isr body — behavior sketch
+
+Prologue loads two struct pointers out of `arg = pciedev_info*`:
+
+```
+r5 = *(arg + 0x18)     ; per-ISR sub-struct ("bus info")
+r6 = *(r5 + 0x18)      ; per-ISR HW-shadow struct (ISR_STATUS container)
+```
+
+Then:
+
+1. Print `"pciedngl_isr called\n"` (via `printf` at 0xA30).
+2. Read status: `r3 = *(r6 + 0x20)` — the ISR_STATUS word.
+3. `tst r3, #0x100` — test bit 8.
+4. If **not set**: print `"%s: invalid ISR status: 0x%08x"` and return (no ACK). This is the "spurious call" path.
+5. If **set**:
+   - `*(r6 + 0x20) = 0x100` — **W1C ACK** (write-one-to-clear of the same bit).
+   - `r0 = *(r5 + 0x20)` (message-pool ptr), `bl 0x4E20` to get a packet descriptor.
+   - If alloc fails → trace `"malloc failure"` + source file `"pciedev_msg.c"` line 250, and bail out.
+   - Else: read the packet buffer length, call a message-read helper at 0x2E10 (reads 0x400 bytes from the HW queue into the newly allocated descriptor), pass it up via `dngl_dev_ioctl` at 0x20D8.
+   - On dngl_dev_ioctl error: print `"%s: error calling dngl_dev_ioctl: %d"`.
+6. Loop back to step 2 while more packets remain (r7 != 0), otherwise print `"pciedngl_isr exits\n"` and return.
+
+### Bit 0x100 cross-reference to upstream
+
+The value 0x100 corresponds to `BRCMF_PCIE_MB_INT_FN0_0` in the host driver
+(`phase5/work/.../brcmfmac/pcie.c:954`), i.e. the FN0 doorbell bit that gets set
+when the host writes `H2D_MAILBOX_1`. The ISR does not read BAR-backed MMIO
+directly — it reads a software shadow at `[r6+0x20]` — but the bit value and
+W1C semantics match the hardware register's behavior exactly, so the shadow
+is populated from (or aliased to) the fw-side MAILBOXINT mirror by the RTE
+IRQ entry path.
+
+## 4. How the flag bit is allocated — `hndrte_add_isr` (0x63C24)
+
+`pcidongle_probe` is at 0x1E90. Near the end it assembles a call to 0x63C24 with the pciedngl_isr fn-ptr literal (0x1C99) in `r3`. Behavior of 0x63C24:
+
+1. `bl 0x1298` allocates a 16-byte node from the RTE heap.
+2. Reads `[0x6296C]` (the HW-class context).
+3. `bl 0x9956` reads `*(ctx + 0xCC)` — appears to be a per-class field.
+4. `bl 0x9990` (name/ID validator — tolerant 0..0xF range check tail-calling 0x27EC).
+5. `bl 0x9940` (dispatch-thunk → 0x2890) returns a **bit index**; `sb = 1`; `[node+0xC] = sb << bit_index`.
+   - For pciedngl_isr this produced bit index 3 → flag = 0x00000008.
+6. `[node+8] = caller-supplied arg`; `[node+4] = r8 = pciedngl_isr fn-ptr`.
+7. Link at the head of `[0x629A4]` list: `next = old head; *[0x629A4] = node`.
+8. **Tail-call 0x99AC → 0x27EC**. 0x99AC is a 1-insn forwarder (`b.w 0x27EC`). 0x99AC and its neighbors (0x99B0/0x99B4/…/0x99C8) form a **9-entry vector** of per-HW-class thunks — each targets a function in the 0x27xx..0x2Axx region. The presence of this vector and its invocation at *exit* of `hndrte_add_isr` is consistent with an "unmask the newly-registered bit at the hardware interrupt-mask register" step.
+
+So: registration does three things at once — allocates a free bit, links the callback node, and tells the HW dispatcher to unmask that bit for this class. **Bit 3 unmasking happens here, not via a host-visible register write.**
+
+### Implication
+
+The fw's "I am ready to receive FN0_0" state is reached only at the return of `hndrte_add_isr(..., pciedngl_isr, ...)` inside `pcidongle_probe`, which itself runs deep inside the RTE post-boot init. Before that point, the FN0_0 doorbell bit is masked at the fw's class-dispatch level even if the HW bit is set. The host writing H2D_MAILBOX_1 before this point either latches (if the fw-side FN0_0 register is level-sensitive and sticky) or is lost (if edge-sensitive).
+
+## 5. Pre-wake handshake expectations
+
+### 5.1 What the blob contains
+
+| Searched literal | Hits in blob | Interpretation |
+|---|---|---|
+| `0x00FF0300` (our MAILBOXMASK value) | **0** | Fw does not compare, read back, or store our scaffold mask literal. |
+| `0x00000300` (int_fn0 combo) | 5 (all false positives in random integer data) | Not used as a distinct mask literal. |
+| `0x00000048` (MAILBOXINT BAR0 offset) | 2 (both false positives — WLRPC ID enum entries 0x47, 0x48, 0x49, …) | Fw does not refer to the host-side BAR0 offset by that number. |
+| `0x00000144` (H2D_MAILBOX_1 BAR0 offset) | **0** | As expected: fw does not write host-doorbell addresses. |
+| `0x10000000` (`BRCMF_PCIE_SHARED_HOSTRDY_DB1`) | 0 in direct-literal search (wider search to do if needed) | Fw's announcement path likely builds this by shifting, not by literal load. |
+
+No host-facing register literal surfaces — consistent with the picture that the fw side accesses its own mirror of MAILBOXINT through the backplane window, not via the PCIe2Reg BAR0 offsets the host uses.
+
+### 5.2 What the upstream host flow requires
+
+From `phase5/work/.../brcmfmac/pcie.c`:
+
+- `#define BRCMF_PCIE_SHARED_HOSTRDY_DB1 0x10000000` (pcie.c:1016)
+- `brcmf_pcie_hostready` (pcie.c:2044) is gated on `devinfo->shared.flags & BRCMF_PCIE_SHARED_HOSTRDY_DB1` — it only writes the H2D_MAILBOX_1 doorbell if fw has advertised the `HOSTRDY_DB1` bit in the shared-RAM `flags` word.
+- `devinfo->shared.flags` is populated from TCM by `brcmf_pcie_init_share_ram_info` (pcie.c:2751) — which runs after firmware download completes AND after fw writes the sharedram_addr into the TCM slot at `ramsize-4`.
+
+So the upstream ordering is:
+1. Host downloads fw and jumps fw execution (chip_set_active).
+2. Fw boots, runs RTE init, runs `pcidongle_probe` → `hndrte_add_isr(..., pciedngl_isr, bit=3)` → FN0_0 unmasked on the fw side.
+3. Fw publishes the shared-RAM pointer + `flags` field, including `HOSTRDY_DB1`.
+4. Host reads shared-RAM, sees `HOSTRDY_DB1` set, calls `brcmf_pcie_hostready` → writes H2D_MAILBOX_1 = 1.
+5. Fw's FN0_0 fires (already unmasked) → scheduler dispatches pciedngl_isr → handshake proceeds.
+
+Our test scaffold does **steps 1 → 2-ish → (skip 3) → 4** — we write H2D_MAILBOX_1 without waiting for `HOSTRDY_DB1`, and we never read the shared-RAM flags field.
+
+## 6. Watchdog / panic search
+
+| Search | Result |
+|---|---|
+| `"panic"` | 0 hits |
+| `"reboot"` | 0 hits |
+| `"watchdog"` | 8 hits — all are *soft* wlc / dngl internal watchdogs (`wlc_phy_watchdog`, `wlc_bmac_watchdog`, `wlc_dngl_ol_bcn_watchdog`, `wlc_dngl_ol_tkip_watchdog`). These are periodic-tick style, not "host must respond or die" timers. |
+| `"reset"` | 29 hits, mostly ai_core / resetctrl debug strings; the one of interest is `"%s: Watchdog reset bit set, clearing"` (blob 0x40C0E) — a *boot-time* check that clears a latched watchdog-reset status, not a runtime timer. |
+| `"deadman_to"` | 1 hit; referenced by the fault-dump handler at 0x63EE4 which *installs* a `deadman_to` RTE timer (2-second armed inside 0x63EE4). Callback at 0x1A8C is 4 instructions and tail-calls the RTE enqueue path — it's a PM/ramstbydis helper, not a host-response killer. |
+
+**Net**: the blob does not contain a "host stopped talking → panic/reboot" watchdog. The fw can be left in WFI indefinitely without self-destructing. Whatever the host sees as the post-scaffold wedge is **not** a fw-initiated reset.
+
+## 7. Implications for the host-side scaffold
+
+### 7.1 What is load-bearing
+
+- **Reading `shared.flags` before writing hostready** is the upstream contract. Our scaffold skips it. This is the single biggest source of "fw wakes in the wrong state."
+- **`brcmf_pcie_intr_enable` (writing MAILBOXMASK=0xFF0300 on the host side) is independent of fw-side unmasking.** It controls whether device-to-host IRQs are delivered. It does not enable anything on the fw side. Writing it early is benign.
+- **`brcmf_pcie_hostready` (writing H2D_MAILBOX_1 = 1) is the thing that can wake fw.** Writing it while fw has not yet run `pcidongle_probe` → `hndrte_add_isr` is the hazardous case.
+
+### 7.2 What the ISR needs from shared memory
+
+pciedngl_isr assumes:
+
+- `pciedev_info*` (the arg) is fully populated, including `+0x18 → sub-struct → +0x18 → HW-shadow struct` with ISR_STATUS at `+0x20`. (Blob-initialized value at +0x18 is 0 — it *must* be populated at runtime by pciedngl_probe.)
+- A message pool is reachable via `*(sub-struct+0x20)` for the malloc at 0x4E20.
+- A dngl_dev_ioctl entry point is set up at `*(sub-struct+0x14)` — this is the call at 0x20D8.
+
+If fw hasn't completed `pcidongle_probe`, these are zero / uninitialized, and the ISR will crash on the first deref. A crash in the fw ARM inside the ISR path is consistent with the silent late-ladder wedge we see: no kernel panic, no AER, no console advance — fw's bus activity stops and the host eventually falls off the bus.
+
+### 7.3 Concrete scaffold-design recommendations
+
+1. **Gate hostready on `shared.flags & 0x10000000`**. Either:
+   - Poll the sharedram_addr slot at `ramsize-4` until it becomes non-zero, read `flags` at `sharedram_addr + 0`, and only call `brcmf_pcie_hostready` after `HOSTRDY_DB1` is observed; OR
+   - Read a debug-ring sentinel that indicates `pcidongle_probe` has completed, and only then ring the doorbell.
+2. **Probe-order invariant**: `brcmf_pcie_intr_enable` is safe to call at any time after `pci_enable_msi` + `request_irq`. **Do not** call `brcmf_pcie_hostready` without the above gate.
+3. **Add a T270-class observation probe** (not a new scaffold) that samples `sharedram_addr` and `shared.flags` at each dwell tick. If `HOSTRDY_DB1` is never observed across a full 120 s ladder, fw is blocked somewhere before `pcidongle_probe`'s ring setup — and the real "why the scaffold wedges host" question is not ISR-side but probe-side (fw never gets to the point where the doorbell would be safe to ring).
+4. **Defer the T270 scaffold rewrite** until the sharedram observation above either confirms or refutes "fw reached ring-init." T258–T269 all rang the doorbell blind; changing that blind-ring to gated-ring is the smallest next change with the highest information value.
+
+### 7.4 What this analysis does NOT settle
+
+- Whether the fw actually reaches pcidongle_probe within the 120 s ladder — static analysis cannot tell us this; requires sharedram polling (see 7.3.3).
+- Which specific sub-field inside `pciedev_info` the ISR NULL-derefs when rung prematurely — the blob's blob-image values at 0x58CC4+{0x18,0x14} are zero, but runtime state may differ based on how far fw got through init.
+- Whether the fw-side MAILBOXINT FN0_0 bit is edge- or level-sensitive (i.e. does an early host doorbell latch or vanish). This is a HW property not derivable from the blob.
+- Which of the 9 thunks in the 0x99AC..0x99C8 vector maps to the PCIe FN0 class specifically — it's class-specific, dispatched via `*(ctx+0xCC)` (the class index). Determining which index the pciedngl class uses would require reading `*(0x6296C)+0xCC` from live hardware, or tracing backward from the 0x28xx handler bodies.
+
+## 8. Artifacts produced by this analysis
+
+- `phase6/t269_disasm.py` — ctypes wrapper around libcapstone.so (the nix capstone Python binding referenced in prior scripts is no longer present in /nix/store, this restores disasm for future T269+ work).
+- `phase6/t269_locate_isr.py` — list walk + prologue check for node[0].
+- `phase6/t269_isr_prologue.py` — full pciedngl_isr + 0x9936 disasm, arg-struct decode.
+- `phase6/t269_mailbox_search.py` — literal / string search for register offsets, MAILBOXMASK values, and watchdog/panic strings.
+- `phase6/t269_regtable_decode.py` — ruled out "MAILBOXINT=0x48 / MAILBOXMASK=0x4C literal" as false positive (WLRPC ID enum); showed pciedev struct vtable at 0x58CF4..0x58CFC.
+- `phase6/t269_hndrte_add_isr.py` — refs to pciedngl_isr fn-ptr 0x1C99, deadman_to string, ramstbydis, 'hndrte_add_isr failed'; and disasm of pcidongle_probe (0x1E90) + scheduler (0x115C).
+- `phase6/t269_add_isr_body.py` — disasm of `hndrte_add_isr` (0x63C24) and the deadman fault-dump handler (0x63EE4).
+- `phase6/t269_hw_enable.py` — disasm of 0x99AC/0x9940/0x9944/0x9956/0x9990/0x1A8C/0x1BA4/0x1298 + vector table region 0x00..0x80.
+
+## 9. Clean-room posture
+
+All code listings in this document are short and illustrative; no complete reconstructed function bodies are checked in. Behavior is described in plain language. Exact instruction sequences used for identification (prologue + ASCII string cross-reference + literal-pool resolution) remain in the helper scripts, which disassemble the vendor blob locally and print to stdout — they are analysis tools, not derived-work source.

--- a/phase6/t269_pciedngl_isr.md
+++ b/phase6/t269_pciedngl_isr.md
@@ -118,7 +118,7 @@ The fw's "I am ready to receive FN0_0" state is reached only at the return of `h
 | `0x00000300` (int_fn0 combo) | 5 (all false positives in random integer data) | Not used as a distinct mask literal. |
 | `0x00000048` (MAILBOXINT BAR0 offset) | 2 (both false positives — WLRPC ID enum entries 0x47, 0x48, 0x49, …) | Fw does not refer to the host-side BAR0 offset by that number. |
 | `0x00000144` (H2D_MAILBOX_1 BAR0 offset) | **0** | As expected: fw does not write host-doorbell addresses. |
-| `0x10000000` (`BRCMF_PCIE_SHARED_HOSTRDY_DB1`) | 0 in direct-literal search (wider search to do if needed) | Fw's announcement path likely builds this by shifting, not by literal load. |
+| `0x10000000` (`BRCMF_PCIE_SHARED_HOSTRDY_DB1`, pcie.c:1016) | 21 raw byte-match hits, **5 at a 4-byte-aligned offset** (0x400, 0x45CAC, 0x504C4, 0x57C18, 0x57C20) | The aligned hits sit in data/table regions, not in obvious literal pools adjacent to code that writes a shared-struct flags field. The fw likely builds this bit by shift/OR (e.g., `1 << 28`) or composes it from per-bit defines rather than loading the combined literal — so absence of a tight code-pool hit does not refute the handshake expectation. Caveat: none of the 5 aligned hits were traced to confirm whether any sits near a shared.flags writer; that is follow-up work. |
 
 No host-facing register literal surfaces — consistent with the picture that the fw side accesses its own mirror of MAILBOXINT through the backplane window, not via the PCIe2Reg BAR0 offsets the host uses.
 

--- a/phase6/t269_regtable_decode.py
+++ b/phase6/t269_regtable_decode.py
@@ -1,0 +1,94 @@
+"""T269: decode what's at blob 0x5000C (contains the 0x48=MAILBOXINT offset)
+and 0x56AD8 / 0x5002C (MAILBOXMASK 0x4C offset). Likely a register-metadata
+table used by a helper function to access mailbox regs.
+
+Also dump the region around pciedngl_isr printf format strings (blob 0x40680+)
+to see the full string neighborhood, and look at what's at 0x58CC4-0x58D00
+(pciedev_info struct initializer).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from t269_disasm import Cs
+
+BLOB = "/home/kimptoc/brcmfmac4360-pcie.bin"
+with open(BLOB, "rb") as f:
+    blob = f.read()
+md = Cs()
+
+
+def u32(off):
+    return int.from_bytes(blob[off:off + 4], "little")
+
+
+def u16(off):
+    return int.from_bytes(blob[off:off + 2], "little")
+
+
+def ascii_str(off, maxlen=64):
+    s = []
+    for i in range(maxlen):
+        b = blob[off + i]
+        if b == 0:
+            break
+        if 32 <= b < 127:
+            s.append(chr(b))
+        else:
+            return None
+    return "".join(s) if s else None
+
+
+def dump_range(start, end, label):
+    print(f"\n=== {label} 0x{start:X}..0x{end:X} ===")
+    for off in range(start, end, 4):
+        v = u32(off)
+        note = ""
+        if 0 < v < len(blob):
+            s = ascii_str(v)
+            if s and len(s) > 2:
+                note = f' -> "{s}"'
+        print(f"  0x{off:06X}: 0x{v:08X}{note}")
+
+
+# 0x5000C region: +0x48 appeared as value. Dump 0x4FFE0..0x50050 (nearby).
+dump_range(0x4FFE0, 0x50060, "MAILBOXINT offset candidate region A (0x5000C)")
+dump_range(0x53800, 0x53840, "MAILBOXMASK offset candidate region B (0x5381C)")
+dump_range(0x56AC0, 0x56B00, "region C (0x56AD8 hit)")
+
+# pciedngl_isr string neighborhood
+print("\n=== String table @ 0x40600..0x40780 (pciedngl_isr strings) ===")
+pos = 0x40600
+while pos < 0x40780:
+    start = pos
+    while pos < 0x40780 and blob[pos] >= 32 and blob[pos] < 127:
+        pos += 1
+    if pos > start:
+        s = blob[start:pos].decode("ascii", "replace")
+        print(f"  0x{start:06X}: {s!r}")
+    # skip nulls
+    while pos < 0x40780 and blob[pos] < 32:
+        pos += 1
+
+# pciedev_info struct initializer at 0x58CC4
+print("\n=== pciedev struct initializer @ 0x58CC4..0x58D40 ===")
+for off in range(0x58CC4, 0x58D40, 4):
+    v = u32(off)
+    note = ""
+    if 0 < v < len(blob):
+        s = ascii_str(v)
+        if s and len(s) > 2:
+            note = f' -> "{s}"'
+        elif v < 0x6C000:
+            # maybe a fn ptr (code)
+            if v & 1:
+                note = " (maybe thumb fn-ptr)"
+    elif 0x80000 <= v < 0xA0000:
+        note = " (TCM BSS/heap)"
+    print(f"  0x{off:06X}: 0x{v:08X}{note}")
+
+# Disassemble the function at 0x9948 (the next entry after 0x9936 at looks like
+# a related getter for a different event-class)
+print("\n=== What is at 0x9948? (next getter after 0x9936) ===")
+for ins in md.disasm(blob[0x9948:0x9970], 0x9948):
+    print(f"  0x{ins.address:06X}: {ins.mnemonic:<10} {ins.op_str}")


### PR DESCRIPTION
## Summary

- Static disassembly (clean-room) of `pciedngl_isr` (blob 0x1C98) and the RTE wake path. All four questions in `phase6/t269_fw_blob_diss.md` are answered.
- Key operational finding: the fw's `hndrte_add_isr(...)` (0x63C24) unmasks the HW bit as the *last* step of ISR registration, and `brcmf_pcie_hostready` is supposed to be gated on `shared.flags & BRCMF_PCIE_SHARED_HOSTRDY_DB1` (0x10000000). Our T258–T269 scaffolds all ring H2D_MAILBOX_1 without waiting for that gate, which is consistent with the late-ladder wedge pattern.
- Concrete recommendation for a follow-up task (not coded here): add a passive `shared.flags` observation probe to the ladder before touching the hostready path. This is the single change with the highest information value and the smallest scaffold churn.

## What landed

- `phase6/t269_pciedngl_isr.md` — the analysis write-up, 9 sections covering entry confirmation, scheduler dispatch, ISR body, registration, handshake expectations, watchdog search, scaffold implications, and clean-room posture.
- `phase6/t269_disasm.py` — ctypes wrapper around `libcapstone.so` (the nix `python3.13-capstone` path referenced by prior phase5 scripts is gone; this restores static-disasm capability for future analysis tasks).
- 7 focused helper scripts: `t269_locate_isr.py`, `t269_isr_prologue.py`, `t269_mailbox_search.py`, `t269_regtable_decode.py`, `t269_hndrte_add_isr.py`, `t269_add_isr_body.py`, `t269_hw_enable.py`. Each maps to one question and prints the reasoning, so the conclusions in the write-up are reproducible.

## Test plan

- [ ] Human review: does the claim "fw waits for HOSTRDY_DB1 before safely servicing H2D_MAILBOX_1" match your understanding of the upstream PCIe protocol?
- [ ] Re-run `phase6/t269_isr_prologue.py` to verify the pciedngl_isr body + 0x9936 output match the write-up.
- [ ] Spot-check `phase6/t269_mailbox_search.py` output: the "0x00FF0300: 0 raw hits" and the WLRPC-ID false-positive explanation.
- [ ] If follow-up T270-style scaffold work lands, verify it adopts the `shared.flags` gate before re-firing a doorbell variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)